### PR TITLE
Alek/fix login

### DIFF
--- a/spylib/__init__.py
+++ b/spylib/__init__.py
@@ -1,4 +1,4 @@
 name = "spylib"
-from .request import InternalServiceRequest
+from .request import ServiceRequestFactory
 from .permission import has_permission
 from .exceptions import LoginException, RefreshException, MethodException

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -27,6 +27,8 @@ class ServiceRequestFactory(object):
         Falls back on trying to log the entity in if access tokens are unavailable.
         """
         try:
+            self.uuid = uuid
+            self.api_key = api_key
             self.access_token = access_token
             self.refresh_token = refresh_token
             self.secret = secret
@@ -100,8 +102,12 @@ class ServiceRequestFactory(object):
                 decode(self.access_token, self.secret, algorithms=[self.algorithm])
             except ExpiredSignatureError:
                 if not self.refresh_token:
-                    raise ExpiredSignatureError
-                self.access_token = self.refresh_access_token(self.refresh_token)
+                    try:
+                        self.login(self.uuid, self.api_key)
+                    except LoginException:
+                        raise LoginException
+                else:
+                    self.access_token = self.refresh_access_token(self.refresh_token)
                 return self.make_service_request(
                     base_url,
                     path=path,

--- a/spylib/tests/test_request.py
+++ b/spylib/tests/test_request.py
@@ -350,7 +350,7 @@ class TestServiceRequestFactory(unittest.TestCase):
         When:
             - a make service request is executed
         Outcome:
-            - ExpiredSignatureError occurs since no new token can be obtained.
+            - LoginError occurs since no token can be obtained upon the login fallback.
         """
         secret = "1234"
         algorithm = "HS256"
@@ -392,7 +392,10 @@ class TestServiceRequestFactory(unittest.TestCase):
             status=201,
             json={"access_token": "1234"},
         )
-        with self.assertRaises(jwt.ExpiredSignatureError):
+        responses.add(
+            responses.POST, "https://auth.localhost:8000/api/v1/login", status=500
+        )
+        with self.assertRaises(LoginException):
             resp.make_service_request(
                 "https://auth.localhost:8000",
                 path="/api/v1/test",


### PR DESCRIPTION
Adds a login fallback when no refresh token is available. 
Raises a LoginException if this fails.