### PR TITLE
ServiceRequestFactory updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.vscode/
 
 # Spyder project settings
 .spyderproject

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.7
+
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+
+RUN pip install -r requirements.txt
+
+COPY spylib /app/spylib
+
+ENV SPYLIB_AUTH_BASE_URL="https://auth.localhost:8000"
+
+CMD python -m unittest

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ def get_service_request_factory():
 Tests are run be unit test discovery. Please run the following command locally to run the suite.
 
 ```
-python3 -m unittest
+docker build -t spylib . && docker run spylib
 ```
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 
 setup(
     name="Spylib",
-    version="v0.0.16",
+    version="v0.0.17",
     packages=setuptools.find_packages(),
     long_description=open("README.md").read(),
     install_requires=["requests>=2.0.0", "PyJWT>=1.7.1", "future>=0.17.0"],

--- a/spylib/__init__.py
+++ b/spylib/__init__.py
@@ -1,4 +1,4 @@
 name = "spylib"
 from .request import ServiceRequestFactory, Observable, Observer
 from .permission import has_permission
-from .exceptions import LoginException, RefreshException, MethodException
+from .exceptions import AuthCredentialException, MethodException

--- a/spylib/exceptions.py
+++ b/spylib/exceptions.py
@@ -2,12 +2,8 @@ from __future__ import absolute_import
 import logging
 
 
-class LoginException(Exception):
-    logging.debug("Login failed for an internal service request.")
-
-
-class RefreshException(Exception):
-    logging.debug("Refresh of access token failed for an internal service request.")
+class AuthCredentialException(Exception):
+    pass
 
 
 class MethodException(Exception):

--- a/spylib/exceptions.py
+++ b/spylib/exceptions.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import logging
 
 
 class AuthCredentialException(Exception):
@@ -7,4 +6,4 @@ class AuthCredentialException(Exception):
 
 
 class MethodException(Exception):
-    logging.debug("An invalid method was passed to the requests library.")
+    pass

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from .exceptions import MethodException, AuthCredentialException
 from builtins import super
 from jwt import decode
+from jwt import ExpiredSignatureError
 from requests import get, delete, post, patch, put
 from six.moves.urllib.parse import urljoin
 import os
@@ -85,7 +86,7 @@ class ServiceRequestFactory(Observable):
         if self.access_token:
             try:
                 decode(self.access_token, self.secret, algorithms=[self.algorithm])
-            except Exception:
+            except ExpiredSignatureError:
                 self.fetch_new_tokens()
         else:
             self.fetch_new_tokens()

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -88,12 +88,12 @@ class ServiceRequestFactory(Observable):
             try:
                 self.refresh_access_token(refresh_token)
             except RefreshException:
-                self.login(uuid, api_key)
+                self.login()
         except (DecodeError, KeyError, Exception) as e:
             raise e
         else:
             if self.access_token is None:
-                self.login(uuid, api_key)
+                self.login()
 
     def _set_access_token(self, access_token):
         self.access_token = access_token
@@ -155,7 +155,7 @@ class ServiceRequestFactory(Observable):
             except ExpiredSignatureError:
                 if not self.refresh_token:
                     try:
-                        self.login(self.uuid, self.api_key)
+                        self.login()
                     except LoginException:
                         raise LoginException
                 else:
@@ -246,7 +246,7 @@ class ServiceRequestFactory(Observable):
             raise RefreshException
         self._set_access_token(access_token)
 
-    def login(self, uuid, api_key):
+    def login(self):
         """
         Login a user on auth, returns access_token and refresh_token.
 

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -8,6 +8,11 @@ from six.moves.urllib.parse import urljoin
 import os
 
 
+# Ensure environment variables are set
+AUTH_BASE_URL = os.environ.get("SPYLIB_AUTH_BASE_URL", None)
+assert AUTH_BASE_URL is not None
+
+
 class Observable(object):
     """
     The observable class that tracks observers, and notifies them when a change occurs.
@@ -223,14 +228,11 @@ class ServiceRequestFactory(Observable):
         """
         Exchanges a refresh token with auth, and returns the subsequent access token.
         """
-        base_url = os.environ.get("SPYLIB_AUTH_BASE_URL", None)
-        if not base_url:
-            raise Exception("SPYLIB_AUTH_BASE_URL must be set.")
         if not refresh_token:
             raise RefreshException
         cookies = {"refresh_token": refresh_token}
         resp = self.make_service_request(
-            base_url,
+            AUTH_BASE_URL,
             "/api/v1/tokens",
             method="POST",
             payload={},
@@ -248,11 +250,8 @@ class ServiceRequestFactory(Observable):
         """
         Login a user on auth, returns access_token and refresh_token.
         """
-        base_url = os.environ.get("SPYLIB_AUTH_BASE_URL", None)
-        if not base_url:
-            raise Exception("SPYLIB_AUTH_BASE_URL must be set.")
         resp = self.make_service_request(
-            base_url,
+            AUTH_BASE_URL,
             "api/v1/login",
             method="POST",
             payload={"api_key": api_key, "uuid": uuid},

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -138,7 +138,7 @@ class ServiceRequestFactory(Observable):
         # Note: We pass a negative retry_count here to prevent an infinite chain
         if resp.status_code in [401] and retry_count >= 0:
             self.fetch_new_tokens()
-            second_resp = self.make_service_request(
+            return self.make_service_request(
                 base_url,
                 path=path,
                 method=method,
@@ -146,7 +146,6 @@ class ServiceRequestFactory(Observable):
                 timeout=timeout,
                 retry_count=-1,
             )
-            return second_resp
 
         # https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
         RETRIABLE_STATUS_CODES = [500, 501, 502, 503, 504, 507]
@@ -235,7 +234,6 @@ class ServiceRequestFactory(Observable):
         resp = self.post(
             AUTH_BASE_URL,
             "api/v1/tokens",
-            timeout=2,
             cookies={"refresh_token": self.refresh_token},
         )
 
@@ -277,7 +275,6 @@ class ServiceRequestFactory(Observable):
         resp = self.post(
             AUTH_BASE_URL,
             "api/v1/login",
-            timeout=2,
             payload={"uuid": self.uuid, "api_key": self.api_key},
         )
 

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -261,7 +261,10 @@ class ServiceRequestFactory(Observable):
             AUTH_BASE_URL,
             "api/v1/login",
             method="POST",
-            payload={"api_key": api_key, "uuid": uuid},
+            payload={
+                "api_key": self.api_key,
+                "uuid": self.uuid
+            },
         )
 
         if resp.status_code != 200:

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -57,7 +57,7 @@ class ServiceRequestFactory(Observable):
     def __init__(
         self,
         uuid,
-        api_key,
+        api_key=None,
         access_token=None,
         secret=None,
         algorithm=None,
@@ -66,6 +66,10 @@ class ServiceRequestFactory(Observable):
         **kwargs
     ):
         super().__init__(**kwargs)
+
+        # Ensure either the API or the access token must be set
+        assert bool(api_key or access_token)
+    
         try:
             self.uuid = uuid
             self.api_key = api_key


### PR DESCRIPTION
This PR does a couple of big things.

1. Makes API key an optional argument to the `ServiceRequestFactory`
2. Adds some sensible defaults to helper methods like `get`, `post`, `patch`, etc.
3. Consolidates login/refresh token cycling into a single function (consumers do not need to be burdened with how this is done, only that it happens).
4. Consolidation of `LoginException` and `RefreshException` into `AuthCredentialException` for easier try/catch in consumer code.
5. Added some defensiveness to calls like `resp.json()`

There's also some minor refactoring of things like the `SPYLIB_AUTH_BASE_URL` being extracted once at the top of the file as opposed to being per-function call.

Tests pass. Version bumped to 0.0.17.