### PR TITLE
Recycle access_token on 403

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 
 setup(
     name="Spylib",
-    version="v0.0.17",
+    version="v0.0.18",
     packages=setuptools.find_packages(),
     long_description=open("README.md").read(),
     install_requires=["requests>=2.0.0", "PyJWT>=1.7.1", "future>=0.17.0"],

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -137,7 +137,7 @@ class ServiceRequestFactory(Observable):
 
         # Check for a credential failure - if so, cycle our tokens and try again w/ no retry
         # Note: We pass a negative retry_count here to prevent an infinite chain
-        if resp.status_code in [401] and retry_count >= 0:
+        if resp.status_code in [401, 403] and retry_count >= 0:
             self.fetch_new_tokens()
             return self.make_service_request(
                 base_url,


### PR DESCRIPTION
A request may be rejected by some services with a 403 (Forbidden) in circumstances where a user has recently been granted a permission, but is using an older `access_token`. To assist with that, we now attempt a token refresh on a 403 as well.