### PR TITLE
Add useful exceptions for all API users

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 
 setup(
     name="Spylib",
-    version="v0.0.18",
+    version="v0.0.19",
     packages=setuptools.find_packages(),
     long_description=open("README.md").read(),
     install_requires=["requests>=2.0.0", "PyJWT>=1.7.1", "future>=0.17.0"],

--- a/spylib/exceptions.py
+++ b/spylib/exceptions.py
@@ -7,3 +7,57 @@ class AuthCredentialException(Exception):
 
 class MethodException(Exception):
     pass
+
+
+class APIException(Exception):
+    default_message = "An API call has failed."
+    default_errors = None
+
+    def __init__(self, message=None, errors=None):
+        setattr(self, "message", message or self.default_message)
+        setattr(self, "errors", errors or self.default_errors)
+
+    def __str__(self):
+        return str(self.message)
+
+
+class BadRequest(APIException):
+    default_message = "Your request is malformed - 400."
+    default_errors = None
+
+
+class NotAuthenticated(APIException):
+    default_message = "You are not authenticated - 401."
+    default_errors = None
+
+
+class PermissionDenied(APIException):
+    default_message = "You are not authorized to access this resource - 403."
+    default_errors = None
+
+
+class NotFound(APIException):
+    default_message = "The resource you requested could not be found - 404."
+    default_errors = None
+
+
+class MethodNotAllowed(APIException):
+    default_message = "Method {method} not allowed - 404."
+    default_errors = None
+
+    def __init__(self, method, message=None, errors=None):
+        if message is None:
+            message = self.default_message.format(method=method)
+
+        super().__init__(message=message, errors=errors)
+
+
+class ServiceUnavailable(APIException):
+    default_message = "The service you are trying to reach is unavailable - {code}."
+    default_errors = None
+
+    def __init__(self, code, message=None, errors=None):
+        if message is None:
+            message = self.default_message.format(code=code)
+
+        super().__init__(message=message, errors=errors)

--- a/spylib/tests/test_exceptions.py
+++ b/spylib/tests/test_exceptions.py
@@ -1,0 +1,71 @@
+from __future__ import absolute_import
+from ..exceptions import (
+    APIException,
+    BadRequest,
+    NotAuthenticated,
+    PermissionDenied,
+    NotFound,
+    MethodNotAllowed,
+    ServiceUnavailable,
+)
+import unittest
+
+
+class ExceptionTestCase(unittest.TestCase):
+    _cls = APIException
+    kwargs = None
+
+    def test_init(self):
+        kwargs = self.kwargs or {}
+        exception = self._cls(**kwargs)
+
+        assert exception.message == self._cls.default_message.format(**kwargs)
+        assert exception.errors == self._cls.default_errors
+
+    def test_raises_with_no_params(self):
+        with self.assertRaises(self._cls):
+            raise self._cls(**(self.kwargs or {}))
+
+    def test_raises_with_message(self):
+        message = "There's a snake in my boots!"
+
+        with self.assertRaises(self._cls) as e:
+            raise self._cls(message=message, **(self.kwargs or {}))
+
+        assert e.exception.message == message
+
+    def test_raises_with_message_and_errors(self):
+        message = "Somebody poisoned the water hole!"
+        errors = ["It was definitely buzz"]
+
+        with self.assertRaises(self._cls) as e:
+            raise self._cls(message=message, errors=errors, **(self.kwargs or {}))
+
+        assert e.exception.message == message
+        assert e.exception.errors == errors
+
+
+class BadRequestTestCase(ExceptionTestCase):
+    _cls = BadRequest
+
+
+class NotAuthenticatedTestCase(ExceptionTestCase):
+    _cls = NotAuthenticated
+
+
+class PermissionDeniedTestCase(ExceptionTestCase):
+    _cls = PermissionDenied
+
+
+class NotFoundTestCase(ExceptionTestCase):
+    _cls = NotFound
+
+
+class MethodNotAllowedTestCase(ExceptionTestCase):
+    _cls = MethodNotAllowed
+    kwargs = {"method": "DELETE"}
+
+
+class ServiceUnavailableTestCase(ExceptionTestCase):
+    _cls = ServiceUnavailable
+    kwargs = {"code": 500}


### PR DESCRIPTION
This PR adds the following exceptions:

- APIException`
- `BadRequest`
- `NotAuthenticated`
- `PermissionDenied`
- `NotFound`
- `MethodNotAllowed`
- `ServiceUnavailable`

Also adds test coverage.