### PR TITLE
Ryan/optional creds

### DIFF
--- a/spylib/request.py
+++ b/spylib/request.py
@@ -100,6 +100,21 @@ class ServiceRequestFactory(Observable):
         self.refresh_token = refresh_token
         self.notify_observers()
 
+    def can_authenticate(self):
+        """
+        Checks if the `ServiceRequestFactory` instance can authenticate.
+
+        Returns:
+            bool: Whether or not the instance is capable of authenticating.
+        """
+        if self.refresh_token is not None:
+            return True
+        
+        if (self.uuid is not None) and (self.api_key is not None):
+            return True
+        
+        return False
+
     @staticmethod
     def urljoin(base_url, path):
         return urljoin(base_url, path)

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -157,7 +157,7 @@ class ServiceRequestFactory(Observable):
             return resp
 
         # Check for a credential failure - if so, cycle our tokens and try again w/ no retry
-        if resp.status_code in [401, 403] and retry_on_401_403:
+        if resp.status_code in [401, 403] and retry_on_401_403 and self.can_authenticate():
             self.fetch_new_tokens()
             return self.make_service_request(
                 base_url,

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -350,10 +350,6 @@ class ServiceRequestFactory(Observable):
             self._fetch_new_access_token_with_refresh_token()
         elif (self.api_key is not None) and (self.uuid is not None):
             self._fetch_tokens_with_api_key()
-        else:
-            raise AuthCredentialException(
-                "Auth token fetch failed - No refresh token or auth credentials were found, login impossible"
-            )
 
     def get_tokens_dict(self):
         return {"access_token": self.access_token, "refresh_token": self.refresh_token}

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -74,9 +74,6 @@ class ServiceRequestFactory(Observable):
     ):
         super(ServiceRequestFactory, self).__init__(*args, **kwargs)
 
-        # Ensure either the API or the access token must be set
-        assert bool(api_key or access_token)
-
         self.uuid = uuid
         self.api_key = api_key
         self.access_token = access_token

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -87,7 +87,9 @@ class ServiceRequestFactory(Observable):
                 decode(self.access_token, self.secret, algorithms=[self.algorithm])
             except ExpiredSignatureError:
                 self.fetch_new_tokens()
-        else:
+        elif self.refresh_token is not None:
+            self.fetch_new_tokens()
+        elif self.uuid is not None and self.api_key is not None:
             self.fetch_new_tokens()
 
     def _set_access_token(self, access_token):

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -63,7 +63,7 @@ class ServiceRequestFactory(Observable):
 
     def __init__(
         self,
-        uuid,
+        uuid=None,
         api_key=None,
         secret=None,
         algorithm=None,

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -339,12 +339,12 @@ class ServiceRequestFactory(Observable):
 
     def fetch_new_tokens(self):
         """
-        Helper method to obtain new token(s) for making service requests.
+        Fetches and updates the tokens on the ServiceRequestFactory instance, if they can be fetched.
+        The method uses a refresh token if it exists, and falls back on the entity UUID/API key if they
+        exist.
 
-        Uses `self.refresh_token` if present, or falls back to using credentials if they are present.
-        Currently this only supports `uuid` and `api_key` as a fallback.
-
-        Raises `AuthCredentialException` if there is a problem.
+        Returns:
+            None
         """
         if self.refresh_token is not None:
             self._fetch_new_access_token_with_refresh_token()


### PR DESCRIPTION
This PR makes ServiceRequestFactory optionally take credentials or tokens. This theoretically allows anonymous users to make use of the ServiceRequestFactory.