### PR TITLE
Ryan/timeout

### DIFF
--- a/spylib/exceptions.py
+++ b/spylib/exceptions.py
@@ -55,6 +55,11 @@ class MethodNotAllowed(APIException):
         )
 
 
+class Timeout(APIException):
+    default_message = "An upstream server timedout."
+    default_errors = None
+
+
 class ServiceUnavailable(APIException):
     default_message = "The service you are trying to reach is unavailable - {code}."
     default_errors = None

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -14,6 +14,7 @@ from jwt import ExpiredSignatureError
 from requests import get, delete, post, patch, put
 from six.moves.urllib.parse import urljoin
 from requests.exceptions import Timeout as RequestsTimeout
+import copy
 
 
 class Observable(object):

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -13,6 +13,7 @@ from jwt import decode
 from jwt import ExpiredSignatureError
 from requests import get, delete, post, patch, put
 from six.moves.urllib.parse import urljoin
+from requests.exceptions import Timeout as RequestsTimeout
 
 
 class Observable(object):
@@ -60,6 +61,13 @@ class ServiceRequestFactory(Observable):
     Storing tokens, and providing configuration is the consumers responsibility when using this library. Fortunately, there are some features provided with spylib that will make this easier.
     When implementing your cross service request, please consider establishing a class that consumes our `Observer` class with a notify functionality. When tokens change in your instance, the observer class will be notified of these changes.
     """
+    METHOD_MAP = {
+        "GET": get,
+        "DELETE": delete,
+        "POST": post,
+        "PATCH": patch,
+        "PUT": put
+    }
     def __init__(
         self,
         uuid=None,
@@ -114,20 +122,6 @@ class ServiceRequestFactory(Observable):
         
         return False
 
-    @staticmethod
-    def urljoin(base_url, path):
-        """
-        Returns a joined URL.
-
-        Args:
-            base_url (str): The base URL to be joined
-            path (str): The path of the URL to be joined
-        
-        Returns:
-            str: A joined URL
-        """
-        return urljoin(base_url, path)
-
     def make_service_request(
         self,
         base_url,
@@ -164,29 +158,64 @@ class ServiceRequestFactory(Observable):
             NotFound: The resource on the service could not be located
             MethodNotAllowed: The service rejected the HTTP method
             ServiceUnavailable: The service returned a 5XX status code
+            Timeout: The service request timed out
             APIException: An unsupported status code was returned
         
         Returns:
             requests.models.Response: A `Response` object including the service's HTTP response
         """
-        headers = kwargs.get("headers", {})
+        if method not in self.METHOD_MAP:
+            raise MethodException
+        
+        # Build our request
+        url = ServiceRequestFactory.urljoin(base_url, path)
+        
+        # Keep a copy of the kwargs around for retries
+        original_kwargs = copy.deepcopy(kwargs)
+        
+        # Pop headers from kwargs so we don't pass it to requests twice
+        headers = kwargs.pop('headers', {})
         if self.access_token:
             headers.update({"Authorization": "Bearer %s" % self.access_token})
-
-        url = ServiceRequestFactory.urljoin(base_url, path)
-
+        
+        # Build keyword arguments that get passed to the specific requests library function
         if method == "GET":
-            resp = get(url, params=payload, headers=headers, timeout=timeout, **kwargs)
-        elif method == "DELETE":
-            resp = delete(url, headers=headers, timeout=timeout, **kwargs)
-        elif method == "POST":
-            resp = post(url, json=payload, headers=headers, timeout=timeout, **kwargs)
-        elif method == "PATCH":
-            resp = patch(url, json=payload, headers=headers, timeout=timeout, **kwargs)
-        elif method == "PUT":
-            resp = put(url, json=payload, headers=headers, timeout=timeout, **kwargs)
+            # Pop params from kwargs so we don't pass it to requests twice
+            params = payload or {}
+            params.update(kwargs.pop('params', {}))
+            additional_kwargs = {"params": params}
+        elif method in ["POST", "PATCH", "PUT"]:
+            # Pop json from kwargs so we don't pass it to requests twice
+            json = payload or {}
+            json.update(kwargs.pop('json', {}))
+            additional_kwargs = {"json": json}
         else:
-            raise MethodException
+            additional_kwargs = {}
+        
+        func = self.METHOD_MAP[method]
+        try:
+            resp = func(
+                url,
+                headers=headers,
+                timeout=timeout,
+                **kwargs,
+                **additional_kwargs
+            )
+        except RequestsTimeout:
+            # Retry if we can, otherwise throw an internal exception
+            if retry_count > 0:
+                return self.make_service_request(
+                    base_url,
+                    path,
+                    method=method,
+                    payload=payload,
+                    timeout=timeout,
+                    retry_count=retry_count - 1,
+                    retry_on_401_403=retry_on_401_403,
+                    **original_kwargs
+                )
+            else:
+                raise Timeout(response=response)
 
         # Eagerly return on successes
         if resp.status_code in [200, 201]:
@@ -203,6 +232,7 @@ class ServiceRequestFactory(Observable):
                 timeout=timeout,
                 retry_count=retry_count - 1,
                 retry_on_401_403=False,
+                **original_kwargs
             )
 
         # Check if we're on the last try, if so, we need to buble an exception
@@ -235,6 +265,7 @@ class ServiceRequestFactory(Observable):
                 timeout=timeout,
                 retry_count=retry_count - 1,
                 retry_on_401_403=retry_on_401_403,
+                **original_kwargs
             )
 
         return resp
@@ -404,3 +435,17 @@ class ServiceRequestFactory(Observable):
 
     def get_tokens_dict(self):
         return {"access_token": self.access_token, "refresh_token": self.refresh_token}
+
+    @staticmethod
+    def urljoin(base_url, path):
+        """
+        Returns a joined URL.
+
+        Args:
+            base_url (str): The base URL to be joined
+            path (str): The path of the URL to be joined
+        
+        Returns:
+            str: A joined URL
+        """
+        return urljoin(base_url, path)


### PR DESCRIPTION
## Description

This pr adds support for retrying on a timeout, which we curiously did not have before. It also has a refactor for how the `params` and `json` kwarg are populated during requests. This refactor was somewhat necessary because previously we just passed `kwargs` into `make_service_request`, which means we could have situations where duplicate keywords are passed into the requests functions.

The approach to fix this is as follows:

For GET requests:
- We begin with the `payload`
- Next we pull `params` from `kwargs`
- Third, we update the payload with params that were supplied in the `params` keyword

For POST, PATCH, PUT requests:
- We begin with the `payload`
- Next we pull `json` from `kwargs`
- Third, we update the payload with the json that was supplied in the `json` keyword

One downside to this approach is that it may not be clear to users how the resolution occurs when both the `payload` and `json` keyword (or `params` in the case of a GET request) will play out.
## Author Checklist

- [x] I have ran the tests locally
- [x] The code builds and runs locally
- [ ] I have resolved all merge conflicts
- [ ] I have evaluated the areas of impact as a user
- [ ] I have added test coverage added for new code
- [ ] I have bumped the version of spylib

_Note: For items that are not applicable, strike 'em out with `~content~`_

## Reviewer Checklist

- [ ] Code abides by standards documented in Notion
- [ ] I have evaluated the code and have given feedback if applicable

_Note: For items that are not applicable, strike 'em out with `~content~`_

## As a reviewer ...

Ways of making the review more helpful, are to include constructive comments, or <strong>praise</strong>, that help foster positive change in our code review culture.
