### PR TITLE
Alek/jitter backoff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,21 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit
-    rev: v1.20.0
+    rev: v2.6.0
     hooks:
       - id: validate_manifest
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 5.0.1
+    rev: 5.0.2
     hooks:
       - id: pydocstyle
   - repo: https://github.com/python-modernize/python-modernize
     rev: '0.7'
     hooks:
       - id: python-modernize
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+  - repo: https://github.com/PyCQA/flake8 
+    rev: 3.8.3
     hooks:
       - id: flake8
-        language_version: python3.7
   - repo: https://github.com/ambv/black
     rev: 19.10b0
     hooks:
       - id: black
-        language_version: python3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 future==0.17.0
-requests==2.21.0
-responses==0.10.6
+requests==2.24.0
+responses==0.10.15
 PyJWT==1.7.1

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -103,8 +103,6 @@ class ServiceRequestFactory(Observable):
         "PUT": put,
     }
 
-    MAX_SLEEP_TIMEOUT = 2
-
     def __init__(
         self,
         uuid=None,
@@ -113,6 +111,7 @@ class ServiceRequestFactory(Observable):
         algorithm=None,
         access_token=None,
         refresh_token=None,
+        sleep_timeout=2,
         *args,
         **kwargs
     ):
@@ -136,7 +135,7 @@ class ServiceRequestFactory(Observable):
         self.refresh_token = refresh_token
         self.secret = secret
         self.algorithm = algorithm
-
+        self.MAX_SLEEP_TIMEOUT = sleep_timeout
         # Attempt to ensure that the access token is usable
         if self.access_token:
             try:

--- a/spylib/request.py
+++ b/spylib/request.py
@@ -16,6 +16,8 @@ from requests import get, delete, post, patch, put
 from six.moves.urllib.parse import urljoin
 from requests.exceptions import Timeout as RequestsTimeout
 import copy
+import time
+import random
 
 
 class Observable(object):
@@ -100,6 +102,8 @@ class ServiceRequestFactory(Observable):
         "PATCH": patch,
         "PUT": put,
     }
+
+    MAX_SLEEP_TIMEOUT = 2
 
     def __init__(
         self,
@@ -191,6 +195,7 @@ class ServiceRequestFactory(Observable):
         timeout=2,
         retry_count=0,
         retry_on_401_403=True,
+        attempts_retried=0,
         **kwargs
     ):
         """
@@ -209,6 +214,7 @@ class ServiceRequestFactory(Observable):
             retry_on_401_403 (bool): Whether or not a retry should occur on a 401 or 403
                 - Note: When this is set to `True`, a 401 or a 403 will cause the `ServiceRequestFactory` to refresh
                   the tokens, and to make the request again - it will only try to refresh the tokens once
+            attempts_retried (int) - Keeps track of the number of times the service request is retried.
             **kwargs: Additional keyword arguments that are passed to the requests method
 
         Raises:
@@ -260,8 +266,10 @@ class ServiceRequestFactory(Observable):
                 kwargs = {}
             resp = func(url, headers=headers, timeout=timeout, **kwargs)
         except RequestsTimeout:
-            # Retry if we can, otherwise throw an internal exception
             if retry_count > 0:
+                time.sleep(
+                    random.random(0, min(self.MAX_SLEEP_TIMEOUT, 2 ** attempts_retried))
+                )
                 return self.make_service_request(
                     base_url,
                     path,
@@ -269,6 +277,7 @@ class ServiceRequestFactory(Observable):
                     payload=payload,
                     timeout=timeout,
                     retry_count=retry_count - 1,
+                    attempts_retried=attempts_retried + 1,
                     retry_on_401_403=retry_on_401_403,
                     **original_kwargs
                 )
@@ -285,6 +294,9 @@ class ServiceRequestFactory(Observable):
             and retry_on_401_403
             and self.can_authenticate()
         ):
+            time.sleep(
+                random.random(0, min(self.MAX_SLEEP_TIMEOUT, 2 ** attempts_retried))
+            )
             self.fetch_new_tokens()
             return self.make_service_request(
                 base_url,
@@ -293,6 +305,7 @@ class ServiceRequestFactory(Observable):
                 payload=payload,
                 timeout=timeout,
                 retry_count=retry_count - 1,
+                attempts_retried=attempts_retried + 1,
                 retry_on_401_403=False,
                 **original_kwargs
             )


### PR DESCRIPTION
## Description

Adds a very basic timeout for making retried API calls.

I've followed some rough guidelines from AWS about adding both a jitter and an exponential backoff in order to ensure we create spread out API requests via a sleep.

The logic right now works as follows:

We sleep based on a jitter between 0, and the result of our exponential backoff.

The exponential backoff is either our maximum back off time, or `2^attempts_retried`. I've set our maximum back off time to be 2 for the time being. 